### PR TITLE
Fix IndexError: list index out of range

### DIFF
--- a/demo/backend.py
+++ b/demo/backend.py
@@ -691,7 +691,7 @@ def bot_stream(messages, workspace, session_id="default"):
             if "</Answer>" in cur_res:
                 finished = True
                 break
-        if chunk.choices[0].finish_reason == "stop" and not finished:
+        if chunk.choices and chunk.choices[0].finish_reason == "stop" and not finished:
             if not cur_res.endswith("</Code>"):
                 cur_res += "</Code>"
                 assistant_reply += "</Code>"


### PR DESCRIPTION
代码在尝试访问 chunk.choices[0] 之前，没有检查 chunk.choices 列表是否为空。

当你使用 client.chat.completions.create 并且设置 stream=True 时，API会返回一个数据流（generator）。这个流会产生多个 chunk（数据块）。

大多数 chunk 会包含 choices 列表，列表中的 delta.content 包含了模型新生成的词。

但是，并非所有 chunk 都保证 choices 列表里有内容。例如，流的最后一个 chunk（或者某些中间的元数据 chunk）可能是一个 choices 为空列表 [] 的对象。