### PR TITLE
fix:correct typo in quantize.py

### DIFF
--- a/quantize.py
+++ b/quantize.py
@@ -88,7 +88,7 @@ def quantize_model_8bit(model_path: str, output_path: str):
     print(f"Saving 8bit quantized model to: {output_path}")
     os.makedirs(output_path, exist_ok=True)
     model.save_pretrained(output_path)
-    tokenizer.save_pretained(output_path)
+    tokenizer.save_pretrained(output_path)
     
     print("8bit quantization completed!")
     return model, tokenizer


### PR DESCRIPTION
This pull request fixes a typo in the `quantize_model_8bit` function in `quantize.py`, correcting the method name used to save the tokenizer. This ensures the tokenizer is properly saved after quantization.

* Fixed a typo by changing `tokenizer.save_pretained` to `tokenizer.save_pretrained` in the `quantize_model_8bit` function, ensuring the tokenizer is saved correctly.  Fixes #80 