### PR TITLE
feat(chat_v2): add MiniMax AI as LLM provider (default MiniMax-M3)

### DIFF
--- a/demo/chat_v2/README.md
+++ b/demo/chat_v2/README.md
@@ -13,6 +13,7 @@
 - Export Markdown and PDF reports
 - Switch between Chinese and English UI
 - Run code either locally or inside Docker
+- Multiple LLM providers: Local (vLLM), HeyWhale API, and [MiniMax AI](https://www.minimaxi.com)
 
 ## Prerequisites
 
@@ -25,6 +26,8 @@ vllm serve DeepAnalyze-8B
 ```
 
 By default the chat demo connects to an OpenAI-compatible endpoint around `http://localhost:8000`.
+
+Alternatively, you can switch the model provider in the UI to **MiniMax AI** and use cloud-hosted models (MiniMax-M2.7) without running a local model service. Just select "MiniMax AI" from the Model Provider dropdown and enter your API key from [MiniMax platform](https://www.minimaxi.com).
 
 ### 2. Python and Node.js
 

--- a/demo/chat_v2/README.md
+++ b/demo/chat_v2/README.md
@@ -27,7 +27,7 @@ vllm serve DeepAnalyze-8B
 
 By default the chat demo connects to an OpenAI-compatible endpoint around `http://localhost:8000`.
 
-Alternatively, you can switch the model provider in the UI to **MiniMax AI** and use cloud-hosted models (MiniMax-M2.7) without running a local model service. Just select "MiniMax AI" from the Model Provider dropdown and enter your API key from [MiniMax platform](https://www.minimaxi.com).
+Alternatively, you can switch the model provider in the UI to **MiniMax AI** and use cloud-hosted models (MiniMax-M3 by default, with MiniMax-M2.7 and MiniMax-M2.7-highspeed also available) without running a local model service. Just select "MiniMax AI" from the Model Provider dropdown and enter your API key from [MiniMax platform](https://www.minimaxi.com).
 
 ### 2. Python and Node.js
 

--- a/demo/chat_v2/README_ZH.md
+++ b/demo/chat_v2/README_ZH.md
@@ -13,6 +13,7 @@
 - 支持导出 Markdown 和 PDF 报告
 - 支持中英文界面切换
 - 支持 local / docker 两种代码执行模式
+- 支持多种 LLM 来源：本地 (vLLM)、和鲸 API、[MiniMax AI](https://www.minimaxi.com)
 
 ## 运行前准备
 
@@ -25,6 +26,8 @@ vllm serve DeepAnalyze-8B
 ```
 
 默认连接 `http://localhost:8000` 附近的 OpenAI 兼容接口。
+
+也可以在界面中将模型来源切换为 **MiniMax AI**，使用云端模型（MiniMax-M2.7），无需运行本地模型服务。只需在"模型来源"下拉菜单中选择"MiniMax AI"，然后输入从 [MiniMax 平台](https://www.minimaxi.com) 获取的 API Key。
 
 ### 2. Python 与 Node.js
 

--- a/demo/chat_v2/README_ZH.md
+++ b/demo/chat_v2/README_ZH.md
@@ -27,7 +27,7 @@ vllm serve DeepAnalyze-8B
 
 默认连接 `http://localhost:8000` 附近的 OpenAI 兼容接口。
 
-也可以在界面中将模型来源切换为 **MiniMax AI**，使用云端模型（MiniMax-M2.7），无需运行本地模型服务。只需在"模型来源"下拉菜单中选择"MiniMax AI"，然后输入从 [MiniMax 平台](https://www.minimaxi.com) 获取的 API Key。
+也可以在界面中将模型来源切换为 **MiniMax AI**，使用云端模型（默认 MiniMax-M3，同时支持 MiniMax-M2.7 与 MiniMax-M2.7-highspeed），无需运行本地模型服务。只需在"模型来源"下拉菜单中选择"MiniMax AI"，然后输入从 [MiniMax 平台](https://www.minimaxi.com) 获取的 API Key。
 
 ### 2. Python 与 Node.js
 

--- a/demo/chat_v2/backend_app/services/chat.py
+++ b/demo/chat_v2/backend_app/services/chat.py
@@ -27,6 +27,8 @@ _STOP_EVENTS_LOCK = threading.Lock()
 HEYWHALE_API_BASE = (
     "https://www.heywhale.com/api/model/services/691d42c36c6dda33df0bf645/app/v1"
 )
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+MINIMAX_DEFAULT_MODEL = "MiniMax-M2.7"
 REMOTE_STOP_SEQUENCES = ["</Code>", "</Answer>"]
 
 
@@ -61,22 +63,36 @@ def _normalize_temperature(value: Any) -> float:
     return max(0.0, min(2.0, temperature))
 
 
+def _normalize_minimax_temperature(value: float) -> float:
+    """Clamp temperature into MiniMax's accepted range (0.01 .. 1.0]."""
+    return max(0.01, min(1.0, value))
+
+
 def build_chat_runtime_config(payload: dict[str, Any] | None) -> ChatRuntimeConfig:
     body = payload or {}
     provider = str(body.get("provider") or "local").strip().lower() or "local"
-    if provider not in {"local", "heywhale"}:
+    if provider not in {"local", "heywhale", "minimax"}:
         provider = "local"
 
     api_base = str(body.get("api_base") or "").strip()
     if provider == "heywhale" and not api_base:
         api_base = HEYWHALE_API_BASE
+    elif provider == "minimax" and not api_base:
+        api_base = MINIMAX_API_BASE
 
-    model = str(body.get("model") or settings.model_path).strip() or settings.model_path
+    model = str(body.get("model") or "").strip()
+    if not model:
+        model = MINIMAX_DEFAULT_MODEL if provider == "minimax" else settings.model_path
+
     api_key = str(body.get("api_key") or "").strip()
+
+    temperature = _normalize_temperature(body.get("temperature"))
+    if provider == "minimax":
+        temperature = _normalize_minimax_temperature(temperature)
 
     return ChatRuntimeConfig(
         provider=provider,
-        temperature=_normalize_temperature(body.get("temperature")),
+        temperature=temperature,
         model=model,
         api_key=api_key,
         api_base=api_base,
@@ -169,6 +185,35 @@ def _iter_heywhale_stream(
                 yield delta, {"choices": [{"finish_reason": finish_reason}]}
 
 
+def _iter_minimax_stream(
+    conversation: list[dict[str, Any]],
+    runtime_config: ChatRuntimeConfig,
+):
+    if not runtime_config.api_key:
+        raise ValueError("MiniMax API key is required")
+
+    minimax_client = openai.OpenAI(
+        base_url=runtime_config.api_base or MINIMAX_API_BASE,
+        api_key=runtime_config.api_key,
+    )
+    response = minimax_client.chat.completions.create(
+        model=runtime_config.model or MINIMAX_DEFAULT_MODEL,
+        messages=conversation,
+        temperature=runtime_config.temperature,
+        stream=True,
+        stop=REMOTE_STOP_SEQUENCES,
+        max_tokens=32768,
+    )
+    try:
+        for chunk in response:
+            delta_content = chunk.choices[0].delta.content if chunk.choices else None
+            yield delta_content, chunk
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+
+
 def _resolve_workspace_selection(
     workspace: Iterable[str] | None,
     workspace_dir: str,
@@ -247,11 +292,12 @@ def bot_stream(
             last_chunk = None
             leading_chunks: list[str] = []
             leading_decided = not should_patch_first_assistant_message
-            stream_iter = (
-                _iter_heywhale_stream(conversation, runtime_config)
-                if runtime_config.provider == "heywhale"
-                else _iter_local_stream(conversation, runtime_config)
-            )
+            if runtime_config.provider == "heywhale":
+                stream_iter = _iter_heywhale_stream(conversation, runtime_config)
+            elif runtime_config.provider == "minimax":
+                stream_iter = _iter_minimax_stream(conversation, runtime_config)
+            else:
+                stream_iter = _iter_local_stream(conversation, runtime_config)
             try:
                 for delta, chunk in stream_iter:
                     if stop_event.is_set():

--- a/demo/chat_v2/backend_app/services/chat.py
+++ b/demo/chat_v2/backend_app/services/chat.py
@@ -28,7 +28,7 @@ HEYWHALE_API_BASE = (
     "https://www.heywhale.com/api/model/services/691d42c36c6dda33df0bf645/app/v1"
 )
 MINIMAX_API_BASE = "https://api.minimax.io/v1"
-MINIMAX_DEFAULT_MODEL = "MiniMax-M2.7"
+MINIMAX_DEFAULT_MODEL = "MiniMax-M3"
 REMOTE_STOP_SEQUENCES = ["</Code>", "</Answer>"]
 
 

--- a/demo/chat_v2/frontend/components/three-panel-interface.tsx
+++ b/demo/chat_v2/frontend/components/three-panel-interface.tsx
@@ -526,7 +526,7 @@ export function ThreePanelInterface() {
       }
 
       const savedProvider = localStorage.getItem("deepanalyze.llmProvider");
-      if (savedProvider === "local" || savedProvider === "heywhale") {
+      if (savedProvider === "local" || savedProvider === "heywhale" || savedProvider === "minimax") {
         setLlmProvider(savedProvider);
       }
 
@@ -538,6 +538,11 @@ export function ThreePanelInterface() {
       const savedApiKey = sessionStorage.getItem("deepanalyze.heywhaleApiKey");
       if (savedApiKey) {
         setHeywhaleApiKey(savedApiKey);
+      }
+
+      const savedMinimaxKey = sessionStorage.getItem("deepanalyze.minimaxApiKey");
+      if (savedMinimaxKey) {
+        setMinimaxApiKey(savedMinimaxKey);
       }
 
       const savedPromptPanel = localStorage.getItem("deepanalyze.showPromptPanel");
@@ -749,9 +754,10 @@ export function ThreePanelInterface() {
   const [showPromptPanel, setShowPromptPanel] = useState(true);
   const [uiLanguage, setUiLanguage] = useState<UILanguage>("en");
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT);
-  const [llmProvider, setLlmProvider] = useState<"local" | "heywhale">("local");
+  const [llmProvider, setLlmProvider] = useState<"local" | "heywhale" | "minimax">("local");
   const [modelTemperature, setModelTemperature] = useState("0.4");
   const [heywhaleApiKey, setHeywhaleApiKey] = useState("");
+  const [minimaxApiKey, setMinimaxApiKey] = useState("");
   const [selectedPresetId, setSelectedPresetId] = useState(
     DATA_ANALYSIS_PROMPT_PRESETS[0]?.id || ""
   );
@@ -781,6 +787,11 @@ export function ThreePanelInterface() {
     if (typeof window === "undefined") return;
     sessionStorage.setItem("deepanalyze.heywhaleApiKey", heywhaleApiKey);
   }, [heywhaleApiKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    sessionStorage.setItem("deepanalyze.minimaxApiKey", minimaxApiKey);
+  }, [minimaxApiKey]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1122,6 +1133,7 @@ export function ThreePanelInterface() {
       modelProvider: uiLanguage === "zh" ? "模型来源" : "Model Provider",
       providerLocal: uiLanguage === "zh" ? "本地" : "Local",
       providerHeywhale: uiLanguage === "zh" ? "和鲸 API" : "HeyWhale API",
+      providerMinimax: uiLanguage === "zh" ? "MiniMax AI" : "MiniMax AI",
       temperature: uiLanguage === "zh" ? "温度" : "Temperature",
       temperatureHint:
         uiLanguage === "zh"
@@ -1132,6 +1144,11 @@ export function ThreePanelInterface() {
         uiLanguage === "zh"
           ? "输入和鲸平台申请的 API Key"
           : "Enter the API key issued by HeyWhale",
+      minimaxApiKey: uiLanguage === "zh" ? "MiniMax API Key" : "MiniMax API Key",
+      minimaxApiKeyPlaceholder:
+        uiLanguage === "zh"
+          ? "输入 MiniMax 平台申请的 API Key"
+          : "Enter the API key from MiniMax platform",
       exportCenter: uiLanguage === "zh" ? "导出中心" : "Export Center",
       exportHint:
         uiLanguage === "zh"
@@ -4236,6 +4253,16 @@ export function ThreePanelInterface() {
       });
       return;
     }
+    if (llmProvider === "minimax" && !minimaxApiKey.trim()) {
+      toastRef.current({
+        description:
+          uiLanguage === "zh"
+            ? "请先填写 MiniMax API Key"
+            : "Please provide a MiniMax API key first.",
+        variant: "destructive",
+      });
+      return;
+    }
     if (!inputValue.trim() && attachments.length === 0) return;
     const baseMessageIndex = messages.length;
     const aiMessageIndex = baseMessageIndex + 1;
@@ -4264,9 +4291,9 @@ export function ThreePanelInterface() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: "DeepAnalyze-8B", // 修正模型名
+          model: llmProvider === "minimax" ? "MiniMax-M2.7" : "DeepAnalyze-8B",
           provider: llmProvider,
-          api_key: llmProvider === "heywhale" ? heywhaleApiKey.trim() : "",
+          api_key: llmProvider === "heywhale" ? heywhaleApiKey.trim() : llmProvider === "minimax" ? minimaxApiKey.trim() : "",
           temperature: normalizedTemperature,
           messages: [
             ...(systemPrompt.trim()
@@ -4669,7 +4696,7 @@ export function ThreePanelInterface() {
                         <Select
                           value={llmProvider}
                           onValueChange={(value) =>
-                            setLlmProvider(value as "local" | "heywhale")
+                            setLlmProvider(value as "local" | "heywhale" | "minimax")
                           }
                         >
                           <SelectTrigger className="w-full rounded-xl">
@@ -4678,6 +4705,7 @@ export function ThreePanelInterface() {
                           <SelectContent>
                             <SelectItem value="local">{textLabels.providerLocal}</SelectItem>
                             <SelectItem value="heywhale">{textLabels.providerHeywhale}</SelectItem>
+                            <SelectItem value="minimax">{textLabels.providerMinimax}</SelectItem>
                           </SelectContent>
                         </Select>
                       </div>
@@ -4713,6 +4741,20 @@ export function ThreePanelInterface() {
                           onChange={(e) => setHeywhaleApiKey(e.target.value)}
                           className="rounded-xl border-gray-200 dark:border-gray-800"
                           placeholder={textLabels.heywhaleApiKeyPlaceholder}
+                        />
+                      </div>
+                    )}
+                    {llmProvider === "minimax" && (
+                      <div>
+                        <div className="mb-1.5 text-xs font-medium text-gray-700 dark:text-gray-300">
+                          {textLabels.minimaxApiKey}
+                        </div>
+                        <Input
+                          type="password"
+                          value={minimaxApiKey}
+                          onChange={(e) => setMinimaxApiKey(e.target.value)}
+                          className="rounded-xl border-gray-200 dark:border-gray-800"
+                          placeholder={textLabels.minimaxApiKeyPlaceholder}
                         />
                       </div>
                     )}

--- a/demo/chat_v2/frontend/components/three-panel-interface.tsx
+++ b/demo/chat_v2/frontend/components/three-panel-interface.tsx
@@ -4291,7 +4291,7 @@ export function ThreePanelInterface() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: llmProvider === "minimax" ? "MiniMax-M2.7" : "DeepAnalyze-8B",
+          model: llmProvider === "minimax" ? "MiniMax-M3" : "DeepAnalyze-8B",
           provider: llmProvider,
           api_key: llmProvider === "heywhale" ? heywhaleApiKey.trim() : llmProvider === "minimax" ? minimaxApiKey.trim() : "",
           temperature: normalizedTemperature,

--- a/demo/chat_v2/tests/test_minimax_integration.py
+++ b/demo/chat_v2/tests/test_minimax_integration.py
@@ -1,0 +1,69 @@
+"""Integration tests for MiniMax provider.
+
+These tests call the real MiniMax API and require a valid MINIMAX_API_KEY
+environment variable. They are skipped by default in CI; run with:
+
+    MINIMAX_API_KEY=<your-key> pytest -m integration demo/chat_v2/tests/
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+_MINIMAX_KEY = os.environ.get("MINIMAX_API_KEY", "")
+_skip_no_key = pytest.mark.skipif(
+    not _MINIMAX_KEY,
+    reason="MINIMAX_API_KEY not set – skipping integration tests",
+)
+
+from backend_app.services.chat import (
+    MINIMAX_API_BASE,
+    MINIMAX_DEFAULT_MODEL,
+    ChatRuntimeConfig,
+    _iter_minimax_stream,
+    build_chat_runtime_config,
+)
+
+
+@_skip_no_key
+@pytest.mark.integration
+class TestMiniMaxLiveAPI:
+    """Integration tests hitting the real MiniMax API."""
+
+    def _make_config(self, **overrides) -> ChatRuntimeConfig:
+        defaults = {
+            "provider": "minimax",
+            "api_key": _MINIMAX_KEY,
+            "model": MINIMAX_DEFAULT_MODEL,
+        }
+        defaults.update(overrides)
+        return build_chat_runtime_config(defaults)
+
+    def test_basic_chat_completion(self):
+        cfg = self._make_config()
+        conversation = [{"role": "user", "content": "Say 'hello' and nothing else."}]
+        chunks = list(_iter_minimax_stream(conversation, cfg))
+        full_text = "".join(c for c, _ in chunks if c)
+        assert len(full_text) > 0
+        assert "hello" in full_text.lower()
+
+    def test_streaming_returns_multiple_chunks(self):
+        cfg = self._make_config()
+        conversation = [{"role": "user", "content": "Count from 1 to 5, one number per line."}]
+        chunks = list(_iter_minimax_stream(conversation, cfg))
+        assert len(chunks) > 1
+
+    def test_temperature_within_range(self):
+        cfg = self._make_config(temperature=0.5)
+        assert cfg.temperature == 0.5
+        conversation = [{"role": "user", "content": "Say 'ok'."}]
+        chunks = list(_iter_minimax_stream(conversation, cfg))
+        full_text = "".join(c for c, _ in chunks if c)
+        assert len(full_text) > 0

--- a/demo/chat_v2/tests/test_minimax_provider.py
+++ b/demo/chat_v2/tests/test_minimax_provider.py
@@ -1,0 +1,258 @@
+"""Unit tests for MiniMax provider integration in chat service."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sys
+from pathlib import Path
+
+# Add the backend_app parent to sys.path so we can import it.
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from backend_app.services.chat import (
+    MINIMAX_API_BASE,
+    MINIMAX_DEFAULT_MODEL,
+    ChatRuntimeConfig,
+    _normalize_minimax_temperature,
+    _normalize_temperature,
+    build_chat_runtime_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Temperature normalisation
+# ---------------------------------------------------------------------------
+
+class TestNormalizeMiniMaxTemperature:
+    """Tests for the MiniMax-specific temperature clamping."""
+
+    def test_clamp_zero_to_lower_bound(self):
+        assert _normalize_minimax_temperature(0.0) == 0.01
+
+    def test_clamp_negative_to_lower_bound(self):
+        assert _normalize_minimax_temperature(-1.0) == 0.01
+
+    def test_clamp_above_one(self):
+        assert _normalize_minimax_temperature(1.5) == 1.0
+
+    def test_value_within_range(self):
+        assert _normalize_minimax_temperature(0.5) == 0.5
+
+    def test_exact_lower_bound(self):
+        assert _normalize_minimax_temperature(0.01) == 0.01
+
+    def test_exact_upper_bound(self):
+        assert _normalize_minimax_temperature(1.0) == 1.0
+
+    def test_standard_temperature_unaffected(self):
+        assert _normalize_minimax_temperature(0.4) == 0.4
+
+
+# ---------------------------------------------------------------------------
+# build_chat_runtime_config – MiniMax provider
+# ---------------------------------------------------------------------------
+
+class TestBuildChatRuntimeConfigMiniMax:
+    """Tests for build_chat_runtime_config when provider is minimax."""
+
+    def test_provider_recognised(self):
+        cfg = build_chat_runtime_config({"provider": "minimax", "api_key": "key123"})
+        assert cfg.provider == "minimax"
+
+    def test_default_model(self):
+        cfg = build_chat_runtime_config({"provider": "minimax", "api_key": "key123"})
+        assert cfg.model == MINIMAX_DEFAULT_MODEL
+
+    def test_default_api_base(self):
+        cfg = build_chat_runtime_config({"provider": "minimax", "api_key": "key123"})
+        assert cfg.api_base == MINIMAX_API_BASE
+
+    def test_custom_api_base(self):
+        cfg = build_chat_runtime_config({
+            "provider": "minimax",
+            "api_key": "key123",
+            "api_base": "https://custom.api.com/v1",
+        })
+        assert cfg.api_base == "https://custom.api.com/v1"
+
+    def test_custom_model(self):
+        cfg = build_chat_runtime_config({
+            "provider": "minimax",
+            "api_key": "key123",
+            "model": "MiniMax-M2.5-highspeed",
+        })
+        assert cfg.model == "MiniMax-M2.5-highspeed"
+
+    def test_temperature_clamped_to_minimax_range(self):
+        cfg = build_chat_runtime_config({
+            "provider": "minimax",
+            "api_key": "key123",
+            "temperature": 1.8,
+        })
+        assert cfg.temperature == 1.0
+
+    def test_zero_temperature_clamped(self):
+        cfg = build_chat_runtime_config({
+            "provider": "minimax",
+            "api_key": "key123",
+            "temperature": 0.0,
+        })
+        assert cfg.temperature == 0.01
+
+    def test_api_key_stored(self):
+        cfg = build_chat_runtime_config({"provider": "minimax", "api_key": "sk-test"})
+        assert cfg.api_key == "sk-test"
+
+    def test_unknown_provider_falls_back_to_local(self):
+        cfg = build_chat_runtime_config({"provider": "unknown_provider"})
+        assert cfg.provider == "local"
+
+    def test_minimax_case_insensitive(self):
+        cfg = build_chat_runtime_config({"provider": "MiniMax", "api_key": "k"})
+        assert cfg.provider == "minimax"
+
+
+# ---------------------------------------------------------------------------
+# build_chat_runtime_config – existing providers still work
+# ---------------------------------------------------------------------------
+
+class TestBuildChatRuntimeConfigExistingProviders:
+    """Regression tests: ensure local and heywhale providers are unaffected."""
+
+    def test_local_provider_default(self):
+        cfg = build_chat_runtime_config({})
+        assert cfg.provider == "local"
+
+    def test_heywhale_provider(self):
+        cfg = build_chat_runtime_config({"provider": "heywhale", "api_key": "hw_key"})
+        assert cfg.provider == "heywhale"
+        assert "heywhale.com" in cfg.api_base
+
+    def test_local_temperature_allows_full_range(self):
+        cfg = build_chat_runtime_config({"provider": "local", "temperature": 1.8})
+        assert cfg.temperature == 1.8
+
+
+# ---------------------------------------------------------------------------
+# _iter_minimax_stream – unit test with mocked OpenAI client
+# ---------------------------------------------------------------------------
+
+class TestIterMiniMaxStream:
+    """Tests for _iter_minimax_stream using mocked OpenAI client."""
+
+    def test_missing_api_key_raises(self):
+        from backend_app.services.chat import _iter_minimax_stream
+
+        cfg = ChatRuntimeConfig(provider="minimax", api_key="")
+        with pytest.raises(ValueError, match="MiniMax API key is required"):
+            list(_iter_minimax_stream([], cfg))
+
+    @patch("backend_app.services.chat.openai.OpenAI")
+    def test_yields_content_from_chunks(self, mock_openai_cls):
+        from backend_app.services.chat import _iter_minimax_stream
+
+        mock_delta = MagicMock()
+        mock_delta.content = "Hello from MiniMax"
+
+        mock_choice = MagicMock()
+        mock_choice.delta = mock_delta
+
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [mock_choice]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([mock_chunk])
+        mock_openai_cls.return_value = mock_client
+
+        cfg = ChatRuntimeConfig(
+            provider="minimax",
+            api_key="test-key",
+            api_base=MINIMAX_API_BASE,
+            model=MINIMAX_DEFAULT_MODEL,
+            temperature=0.4,
+        )
+        results = list(_iter_minimax_stream([{"role": "user", "content": "hi"}], cfg))
+        assert len(results) == 1
+        assert results[0][0] == "Hello from MiniMax"
+
+    @patch("backend_app.services.chat.openai.OpenAI")
+    def test_passes_correct_params_to_openai_client(self, mock_openai_cls):
+        from backend_app.services.chat import _iter_minimax_stream
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([])
+        mock_openai_cls.return_value = mock_client
+
+        cfg = ChatRuntimeConfig(
+            provider="minimax",
+            api_key="my-key",
+            api_base="https://api.minimax.io/v1",
+            model="MiniMax-M2.7",
+            temperature=0.7,
+        )
+        conversation = [{"role": "user", "content": "test"}]
+        list(_iter_minimax_stream(conversation, cfg))
+
+        mock_openai_cls.assert_called_once_with(
+            base_url="https://api.minimax.io/v1",
+            api_key="my-key",
+        )
+        mock_client.chat.completions.create.assert_called_once()
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs["temperature"] == 0.7
+        assert call_kwargs["stream"] is True
+
+    @patch("backend_app.services.chat.openai.OpenAI")
+    def test_none_delta_yields_none(self, mock_openai_cls):
+        from backend_app.services.chat import _iter_minimax_stream
+
+        mock_chunk = MagicMock()
+        mock_chunk.choices = []
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([mock_chunk])
+        mock_openai_cls.return_value = mock_client
+
+        cfg = ChatRuntimeConfig(
+            provider="minimax",
+            api_key="key",
+            api_base=MINIMAX_API_BASE,
+            model=MINIMAX_DEFAULT_MODEL,
+            temperature=0.4,
+        )
+        results = list(_iter_minimax_stream([{"role": "user", "content": "hi"}], cfg))
+        assert results[0][0] is None
+
+
+# ---------------------------------------------------------------------------
+# bot_stream provider routing
+# ---------------------------------------------------------------------------
+
+class TestProviderRouting:
+    """Verify that the provider selection in build_chat_runtime_config routes correctly."""
+
+    def test_minimax_config_creates_correct_provider(self):
+        cfg = build_chat_runtime_config({
+            "provider": "minimax",
+            "api_key": "test-key",
+        })
+        assert cfg.provider == "minimax"
+        assert cfg.api_base == MINIMAX_API_BASE
+        assert cfg.model == MINIMAX_DEFAULT_MODEL
+
+    def test_local_config_creates_correct_provider(self):
+        cfg = build_chat_runtime_config({"provider": "local"})
+        assert cfg.provider == "local"
+
+    def test_heywhale_config_creates_correct_provider(self):
+        cfg = build_chat_runtime_config({
+            "provider": "heywhale",
+            "api_key": "hw-key",
+        })
+        assert cfg.provider == "heywhale"

--- a/demo/chat_v2/tests/test_minimax_provider.py
+++ b/demo/chat_v2/tests/test_minimax_provider.py
@@ -84,9 +84,9 @@ class TestBuildChatRuntimeConfigMiniMax:
         cfg = build_chat_runtime_config({
             "provider": "minimax",
             "api_key": "key123",
-            "model": "MiniMax-M2.5-highspeed",
+            "model": "MiniMax-M2.7-highspeed",
         })
-        assert cfg.model == "MiniMax-M2.5-highspeed"
+        assert cfg.model == "MiniMax-M2.7-highspeed"
 
     def test_temperature_clamped_to_minimax_range(self):
         cfg = build_chat_runtime_config({
@@ -192,7 +192,7 @@ class TestIterMiniMaxStream:
             provider="minimax",
             api_key="my-key",
             api_base="https://api.minimax.io/v1",
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             temperature=0.7,
         )
         conversation = [{"role": "user", "content": "test"}]
@@ -204,7 +204,7 @@ class TestIterMiniMaxStream:
         )
         mock_client.chat.completions.create.assert_called_once()
         call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs["model"] == "MiniMax-M3"
         assert call_kwargs["temperature"] == 0.7
         assert call_kwargs["stream"] is True
 


### PR DESCRIPTION
## Summary

- Add [MiniMax AI](https://www.minimaxi.com) as a third model provider in the chat demo alongside Local (vLLM) and HeyWhale API
- Users can now select "MiniMax AI" from the Model Provider dropdown and use cloud-hosted MiniMax models without running a local model service
- **Default model is `MiniMax-M3`** (512K context window, up to 128K output, image-input capable). `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are still selectable via the `model` field
- Includes MiniMax-specific temperature clamping (0.01-1.0) and API key management in both backend and frontend

## Changes

**Backend** (`demo/chat_v2/backend_app/services/chat.py`):
- `_iter_minimax_stream()`: new streaming function using OpenAI-compatible SDK with MiniMax base URL
- `_normalize_minimax_temperature()`: clamps temperature to MiniMax-accepted range [0.01, 1.0]
- Extended `build_chat_runtime_config()` with `minimax` provider routing, auto-defaults for API base and model (`MiniMax-M3`)
- Updated `bot_stream()` dispatch to route minimax provider to the new stream iterator

**Frontend** (`demo/chat_v2/frontend/components/three-panel-interface.tsx`):
- Added MiniMax AI option in Model Provider Select dropdown
- Added MiniMax API Key input with sessionStorage persistence
- Validation: blocks send if MiniMax is selected without API key
- Sends correct model name (`MiniMax-M3`) when MiniMax provider is active

**Documentation** (`demo/chat_v2/README.md`, `demo/chat_v2/README_ZH.md`):
- Listed MiniMax AI as a supported provider in features
- Default model documented as `MiniMax-M3`; alternatives `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` noted

**Tests** (`demo/chat_v2/tests/test_minimax_provider.py`):
- Replaced removed `MiniMax-M2.5-highspeed` example with `MiniMax-M2.7-highspeed`
- Default-model assertion updated to `MiniMax-M3`

## Why MiniMax-M3 as the new default

`MiniMax-M3` is the latest MiniMax model: 512K context window, up to 128K output, and image-input support — better suited to long data-analysis transcripts than M2.7 (192K context, 32K output).

## Test plan

- [x] Unit tests in `demo/chat_v2/tests/test_minimax_provider.py` updated to reflect new default model
- [x] Integration tests in `demo/chat_v2/tests/test_minimax_integration.py` use `MINIMAX_DEFAULT_MODEL` (= `MiniMax-M3`) and continue to pass
- [ ] Manual: select MiniMax AI in UI, enter API key, send a data-analysis prompt — verifies MiniMax-M3 end-to-end
- [ ] Verify Local and HeyWhale providers still work unchanged