### PR TITLE
fix: prevent code & command injection in DSBench score4each_com.py

### DIFF
--- a/playground/DSBench/data_modeling/score4each_com.py
+++ b/playground/DSBench/data_modeling/score4each_com.py
@@ -1,12 +1,15 @@
 import os
 import json
+import re
+import subprocess
+import sys
 from tqdm import tqdm
 import time
 
 data = []
 with open("./data.json", "r") as f:
     for line in f:
-        data.append(eval(line))
+        data.append(json.loads(line))
 
 print(data)
 
@@ -25,16 +28,31 @@ pred_path = f"./output_model/{model}/"
 save_path = f"./save_performance/{model}"
 
 for line in data:
+    name = line["name"]
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", name):
+        raise ValueError(f"Invalid dataset name: {name!r}")
     # print(line['name'])
-    answer_file = gt_path + line["name"] + "/test_answer.csv"
-    pred_file = pred_path + line["name"] + ".csv"
+    answer_file = gt_path + name + "/test_answer.csv"
+    pred_file = pred_path + name + ".csv"
     # pred_file = pred_path + line['name'] + '/test_answer.csv'
     # print(pred_file)
     if os.path.exists(pred_file):
         # print(pred_file)
-        if not os.path.exists(os.path.join(save_path, line["name"])):
-            os.makedirs(os.path.join(save_path, line["name"]))
-        print(f"compute performance for {line['name']}")
-        os.system(
-            f"python {python_path}{line['name']}_eval.py --answer_file {answer_file} --predict_file {pred_file} --path {save_path} --name {line['name']}"
+        if not os.path.exists(os.path.join(save_path, name)):
+            os.makedirs(os.path.join(save_path, name))
+        print(f"compute performance for {name}")
+        subprocess.run(
+            [
+                sys.executable,
+                os.path.join(python_path, f"{name}_eval.py"),
+                "--answer_file",
+                answer_file,
+                "--predict_file",
+                pred_file,
+                "--path",
+                save_path,
+                "--name",
+                name,
+            ],
+            check=False,
         )


### PR DESCRIPTION
## Summary

`playground/DSBench/data_modeling/score4each_com.py` contains two related issues that allow arbitrary code/command execution if `data.json` is ever attacker-influenced:

1. **Arbitrary code execution via `eval()`** (CWE-94): Each line of `./data.json` is parsed with `eval(line)` rather than `json.loads`. Anything in that file is executed as Python.
2. **OS command injection via `os.system` f-string** (CWE-78): The `name` field from each entry is interpolated directly into a shell command:
   ```python
   os.system(f"python {python_path}{line['name']}_eval.py --answer_file ...")
   ```
   A `name` containing shell metacharacters (e.g. `foo; rm -rf ~`) is executed by the shell.

Severity: high when triggered (local RCE on the user running the benchmark), but exploitation requires write/influence over `data.json`.

## Fix

Minimal change to the single script — see `playground/DSBench/data_modeling/score4each_com.py`:

- Replace `eval(line)` with `json.loads(line)` so the dataset list is treated as data, not code.
- Validate `name` against a strict allowlist (`re.fullmatch(r"[A-Za-z0-9_-]+", name)`); raise `ValueError` on anything else. This matches the shape of legitimate dataset directory names already used by the benchmark.
- Replace `os.system(f"...")` with `subprocess.run([...], check=False)` using an argv list and `sys.executable`, so no shell is involved and arguments cannot be reinterpreted as shell syntax.

Behaviour for legitimate inputs is unchanged: the same Python interpreter runs the same `<name>_eval.py` with the same arguments. Only malformed/malicious entries are rejected.

## Testing

- Confirmed `data.json` in the repo parses identically under `json.loads` (it is line-delimited JSON; `eval` was only "working" because JSON happens to be valid Python literal syntax for these entries).
- Verified the regex accepts every `name` value present in the committed `data.json`.
- Manually constructed a malicious entry (`{"name": "foo; touch /tmp/pwn"}`) and confirmed:
  - Before the fix: the shell executes `touch /tmp/pwn`.
  - After the fix: `ValueError: Invalid dataset name: 'foo; touch /tmp/pwn'` is raised before any subprocess is spawned.
- Confirmed `subprocess.run([...])` with `shell=False` (default) does not interpret metacharacters in argv.

## Security analysis

The exploit primitive is straightforward:

- An attacker who can modify or supply `playground/DSBench/data_modeling/data.json` (e.g. a contributor PR that updates the dataset list, a downloaded dataset manifest, or anyone who can write that file on the user's machine) can either:
  - inject Python via the `eval()` call (any line is executed), or
  - inject a shell command via the `name` field reaching `os.system`.
- Triggering only requires the user to run the benchmark scoring script, which is its documented purpose.

The fix removes both primitives: `json.loads` cannot execute code, the allowlist rejects shell metacharacters before they ever leave the script, and `subprocess.run` with an argv list removes the shell from the execution path. Defence in depth — any one of the three changes would block the current PoC, but together they also harden against future regressions (e.g. a future caller passing a different `name` source).

### Adversarial review

Before submitting, we tried to disprove this. The script is local and not internet-facing, so we considered whether the precondition ("attacker controls `data.json`") collapses into "attacker already has full repo write" and is therefore not worth fixing. It doesn't: `data.json` is a benchmark manifest that researchers routinely regenerate, extend, or merge from third-party dataset lists and contributor PRs, so untrusted content can land there without granting the contributor general code-execution rights. We also checked whether any upstream validation of `data.json` exists — none does; the file is consumed directly. Given the fix is a few lines, has no behavioural cost for legitimate inputs, and closes both an `eval()` and an `os.system` sink, we think it's worth landing.

cc @lewiswigmore
