### PR TITLE
Restrict SQL execution tool to read-only queries (CWE-89)

### DIFF
--- a/deepanalyze/SkyRL/skyrl-gym/skyrl_gym/tools/sql.py
+++ b/deepanalyze/SkyRL/skyrl-gym/skyrl_gym/tools/sql.py
@@ -5,6 +5,17 @@ import sqlite3
 import sys
 import os
 
+_ALLOWED_SQL_ACTIONS = {
+    sqlite3.SQLITE_SELECT,
+    sqlite3.SQLITE_READ,
+    sqlite3.SQLITE_FUNCTION,
+}
+
+
+def _is_read_only_sql(action_code):
+    """Return True if SQLite is only preparing read-only operations."""
+    return action_code in _ALLOWED_SQL_ACTIONS
+
 
 class SQLCodeExecutorToolGroup(ToolGroup):
     def __init__(self, db_file_path: str):
@@ -15,17 +26,25 @@ class SQLCodeExecutorToolGroup(ToolGroup):
     def sql(self, db_id, sql, turns_left, timeout=5) -> str:
         def _execute_sql(db_file, sql):
             try:
-                conn = sqlite3.connect(db_file)
+                # Open database in read-only mode and let SQLite reject non-read operations.
+                conn = sqlite3.connect(f"file:{db_file}?mode=ro", uri=True)
+                conn.set_authorizer(
+                    lambda action, _arg1, _arg2, _db, _trigger: (
+                        sqlite3.SQLITE_OK
+                        if _is_read_only_sql(action)
+                        else sqlite3.SQLITE_DENY
+                    )
+                )
                 cursor = conn.cursor()
-                conn.execute("BEGIN TRANSACTION;")
                 cursor.execute(sql)
                 execution_res = frozenset(cursor.fetchall())
-                conn.rollback()
                 conn.close()
                 return execution_res
             except Exception as e:
-                conn.rollback()
-                conn.close()
+                try:
+                    conn.close()
+                except Exception:
+                    pass
                 return f"Error executing SQL: {str(e)}, db file: {db_file}"
 
         def _execute_sql_wrapper(db_file, sql, timeout=5) -> str:
@@ -51,6 +70,15 @@ class SQLCodeExecutorToolGroup(ToolGroup):
                 res = f"SQL Timeout:\n{sql}"
             except Exception as e:
                 res = str(e)
+
+            if isinstance(res, str) and (
+                "not authorized" in res.lower()
+                or "you can only execute one statement" in res.lower()
+            ):
+                res = (
+                    "SQL blocked: only read-only SELECT queries are allowed. "
+                    "Statements that modify data or database structure are not permitted."
+                )
 
             return res
 


### PR DESCRIPTION
## Summary

The `SQLCodeExecutorToolGroup.sql()` tool in `deepanalyze/SkyRL/skyrl-gym/skyrl_gym/tools/sql.py` executes arbitrary SQL strings produced by the LLM agent against a writable SQLite connection. The code relies on a `BEGIN TRANSACTION` / `rollback()` pair to "undo" any side effects, but several SQL operations are not transactional in SQLite and persist regardless of rollback — most notably `ATTACH DATABASE`, `DETACH DATABASE`, schema/`PRAGMA` changes affecting connection state, and writes through attached databases. Even ignoring that, a thrown exception or process kill mid-query leaves writes committed.

This is CWE-89 (Improper Neutralization of Special Elements used in an SQL Command) in the sense that an untrusted producer of SQL (the model) can execute statements outside the intended SELECT-only contract of a text-to-SQL training/eval tool.

**Affected file/function:** `deepanalyze/SkyRL/skyrl-gym/skyrl_gym/tools/sql.py` → `SQLCodeExecutorToolGroup.sql` → `_execute_sql`

**Data flow:** model-generated `sql` argument → `cursor.execute(sql)` on a read/write `sqlite3.connect(db_file)` connection → side effects on the on-disk training database.

## Fix

Two layers of defense, both in `_execute_sql`:

1. **Open the database in read-only mode** via the SQLite URI form: `sqlite3.connect(f"file:{db_file}?mode=ro", uri=True)`. SQLite itself refuses any write at the VFS layer.
2. **Install an authorizer callback** that only permits `SQLITE_SELECT`, `SQLITE_READ`, and `SQLITE_FUNCTION` actions, denying everything else (DDL, DML, `ATTACH`, `PRAGMA` writes, etc.). This catches statements that are syntactically read-only but semantically dangerous (e.g. `ATTACH`).

The now-redundant `BEGIN TRANSACTION` / `rollback()` pair is removed, since the connection cannot write. A friendly error message is returned to the agent when a statement is blocked, so training/eval loops get a clear signal rather than a raw SQLite error.

The change is scoped to a single function and does not alter the tool's public interface or the shape of successful results.

## Testing

I exercised the modified `_execute_sql` against a temporary SQLite database with a sample table:

- ✅ `SELECT * FROM users` — returns rows as before (frozenset of tuples), unchanged behaviour.
- ✅ `WITH cte AS (SELECT 1) SELECT * FROM cte` — CTE/`WITH` queries still work (authorizer permits `SELECT`/`READ`/`FUNCTION`).
- ✅ `SELECT count(*), upper(name) FROM users` — aggregate and scalar functions still work (`SQLITE_FUNCTION` allowed).
- ✅ `DROP TABLE users` — blocked, returns the friendly "SQL blocked: only read-only SELECT queries are allowed" message; table still present afterward.
- ✅ `INSERT INTO users VALUES (...)` — blocked, no row added.
- ✅ `UPDATE users SET name='x'` — blocked, data unchanged.
- ✅ `ATTACH DATABASE '/tmp/evil.db' AS evil` — blocked by the authorizer (this was the most important case, since `ATTACH` is not undone by `rollback()` and was exploitable pre-fix).
- ✅ `PRAGMA writable_schema=ON` — blocked.
- ✅ Multi-statement payloads (`SELECT 1; DROP TABLE users`) — rejected by `cursor.execute`'s "you can only execute one statement at a time" check, message normalized.

After the test run, the on-disk database file's mtime and contents were unchanged in every blocked case.

## Security analysis

The agent driving this tool is the LLM under training/evaluation, not a remote network user, so this is not a classic internet-facing SQLi. However the trust boundary is real: the SQL tool is intended as a read-only text-to-SQL execution surface, and a misaligned, jailbroken, or simply buggy model can emit arbitrary SQL. Pre-fix, such a model could:

- `DROP` or `ALTER` tables in the training database, corrupting subsequent rollouts.
- `ATTACH` an arbitrary file path as a database (the rollback does *not* detach it), then read/write through it — useful for persistence or for staging data in unexpected locations.
- Modify `sqlite_master` via `PRAGMA writable_schema` and `UPDATE`.
- Cause non-rollback-safe side effects via crashes mid-statement.

Post-fix, the OS-level connection is read-only and the authorizer denies non-read actions before they reach the VFS, so none of the above are reachable from this tool.

### Adversarial review

Before submitting I tried to disprove this finding: the obvious counter-argument is "the rollback already undoes any writes, so there's no real impact." That doesn't hold up — `ATTACH DATABASE` and several PRAGMA effects are not rolled back by `conn.rollback()`, and an exception path or process termination between `execute` and `rollback` also leaves writes committed. I also checked whether the tool is gated by some upstream sanitizer or is only called with model outputs that have been validated; it isn't — `sql` is passed straight from the tool call to `cursor.execute`. The fix is therefore both necessary and minimal.

cc @lewiswigmore
