### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,4 +456,4 @@ Welcome to join the [DeepAnalyze WeChat group](./assets/wechat.jpg), chat and sh
 
 If you like DeepAnalyze, give it a GitHub Star ⭐. 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ruc-datalab/DeepAnalyze&type=date&legend=top-left)](https://www.star-history.com/#ruc-datalab/DeepAnalyze&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ruc-datalab/DeepAnalyze&type=date&legend=top-left)](https://star-history.dera.page/#ruc-datalab/DeepAnalyze&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken and does not display. This pull request updates the chart link so it renders correctly again, making the project's popularity and growth easy to see at a glance. Thanks for all the stars and support.